### PR TITLE
Make build reproducible with rust-toolchain

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2020-11-25"
+components = ["rustc-dev"]
+


### PR DESCRIPTION
Before, you'd have to install the exact toolchain and figure out you needed rustc-dev.