### PR TITLE
Add missing llvm component

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "nightly-2020-11-25"
-components = ["rustc-dev"]
+components = ["rustc-dev", "llvm-tools-preview"]
 


### PR DESCRIPTION
Otherwise this would fail to link:

```
  = note: ld.lld: error: unable to find library -lLLVM-11-rust-1.50.0-nightly
```

Oops.